### PR TITLE
on_close event listener support. datetime_to_dict utility function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ async def on_disconnect(client, code, reason):
     print(f"Client at {client.remote_address} disconnected with code: ", code, "and reason: ", reason)
     print(server.disconnected_clients)
 
+@server.on("close")
+async def on_close(client, code, reason):
+    print(f"Client at {client.remote_address} closed connection with code: {code} and reason: {reason}")
+
 server.listen("localhost", 3000)
 ```
 
@@ -57,6 +61,10 @@ async def on_message(message):
 async def on_disconnect(code, reason):
     print(f"{client.connection} disconnect with code: ", code, "and reason: ", reason)
     print(client.disconnection)
+
+@client.on("close")
+async def on_close(code, reason):
+    print(f"{client.connection.remote_address} closed connection with code: {code} and reason: {reason}")
 
 client.connect("ws://localhost:3000")
 ```

--- a/README.md
+++ b/README.md
@@ -69,5 +69,9 @@ async def on_close(code, reason):
 client.connect("ws://localhost:3000")
 ```
 
-## Why this exists?
+## FAQ
+### What's the difference between `on_disconnect` and `on_close` event listeners ?
+The difference isn't huge but it is there. `on_disconnect` event is fired only if the client or the server **did not** closed the connection properly, the TCP Connection was lost suddenly raising the websockets' ConnectionClosedError in the libraries internal message consumer. In such cases the code returned is usually `1006` and there is no reason. While `on_close` event listener is called if the connection was closed properly, that could be done by calling the libraries' ClientSocket or ServerSocket's `.close` method and providing a reason and error code optionally. This causes the internal message consumer task on both sides to exit / return that in turn calls the attached listener functions. 
+**Note:** Unlike `on_disconnect` listener, `on_close` is called on both sides that is both on the client and server websocket sides with the same reason and code.
+### Why this exists?
 I made this library because I was fed up of websockets library because it didn't have event based communication like Node.js's ws library and that made it difficult to work about it. Before I was doubtful whether I would work on it anymore or not... but it has went on to become a pretty large library but still not well known as of now... 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ async def on_message(message):
     if message.data.startswith("!confirm"):
         await message.author.send("Send yes or no?")
         try:
-            conmes = await server.wait_for('message', timeout=1, check=lambda rm: rm.data.lower().strip() in ['yes', 'no'] and rm.author.remote_address == message.author.remote_address)
+            conmes = await server.wait_for(
+                'message', 
+                timeout=300, 
+                check=lambda rm: rm.data.lower().strip() in ['yes', 'no'] and rm.author.remote_address == message.author.remote_address)
             print(conmes.data)
             if conmes.data.lower().strip() == 'yes':
                 await conmes.author.send("done")
@@ -128,9 +131,13 @@ async def on_message(message):
     if message.data in ['done', 'not done']:
         return
     await asyncio.sleep(3)
-    await message.author.send("This is a random message. This won't be collected by the event collector on the server side due to the check condition.")
+    await message.author.send(
+         "This is a random message. This won't be collected by the event collector on the server side due to the check condition."
+    )
     await asyncio.sleep(3)
-    await message.author.send("yes") #this will be collected and you would receive a response "done" for this, provide "no" and you will get "not done" response
+    await message.author.send(
+        "yes"
+    ) #this will be collected and you would receive a response "done" for this, provide "no" and you will get "not done" response
 
 @client.on('disconnect')
 async def on_disconnect(code, reason):

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Event collector (.wait_for method) example.
 `server.py`
 ```py
 import ws
+import asyncio
 
 server = ws.ServerSocket()
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # ws
 WebSocket implementation in Python built on top of websockets python library. Similar to Node.js's ws.
 
-### Under Development
-
-Few examples for now.
+Basic usage.
 
 `server.py`
 ```py
@@ -68,6 +66,83 @@ async def on_close(code, reason):
 
 client.connect("ws://localhost:3000")
 ```
+
+Event collector (.wait_for method) example.
+
+`server.py`
+```py
+import ws
+
+server = ws.ServerSocket()
+
+@server.on('ready')
+async def on_ready():
+    print(f"Server is ready listening at ws://{server.address}:{server.port}")
+
+@server.on('connect')
+async def on_connect(websocket, path):
+    print(f"Client at {websocket.remote_address} connected.")
+
+@server.on('message')
+async def on_message(message):
+    print(f"{message.data}")
+    if message.data.startswith("!confirm"):
+        await message.author.send("Send yes or no?")
+        try:
+            conmes = await server.wait_for('message', timeout=1, check=lambda rm: rm.data.lower().strip() in ['yes', 'no'] and rm.author.remote_address == message.author.remote_address)
+            print(conmes.data)
+            if conmes.data.lower().strip() == 'yes':
+                await conmes.author.send("done")
+            else:
+                await conmes.author.send("not done")
+        except asyncio.TimeoutError:
+            await message.author.send("Timed out!")
+
+@server.on('disconnect')
+async def on_disconnect(client, code, reason):
+    print(f"{client} disconnect with code:", code, reason)
+    print(server.disconnected_clients)
+
+@server.on("close")
+async def on_close(client, code, reason):
+    print(f"{client.remote_address} closed connection with code: {code} and reason: {reason}")
+
+server.listen("localhost", 3000)
+```
+
+`client.py`
+```py
+import ws
+import asyncio
+
+client = ws.ClientSocket()
+
+@client.on('connect')
+async def on_connect():
+    print(f"Connected to {client.connection.remote_address}")
+    await client.send(content="!confirm")
+
+@client.on('message')
+async def on_message(message):
+    print(f'{message.data}')
+    if message.data in ['done', 'not done']:
+        return
+    await asyncio.sleep(3)
+    await message.author.send("This is a random message. This won't be collected by the event collector on the server side due to the check condition.")
+    await asyncio.sleep(3)
+    await message.author.send("yes") #this will be collected and you would receive a response "done" for this, provide "no" and you will get "not done" response
+
+@client.on('disconnect')
+async def on_disconnect(code, reason):
+    print(f"{client.connection} disconnect with code:", code, reason)
+    print(client.disconnection)
+
+@client.on("close")
+async def on_close(code, reason):
+    print(f"{client.connection.remote_address} closed connection with code: {code} and reason: {reason}")
+
+client.connect("ws://localhost:3000")
+``` 
 
 ## FAQ
 ### What's the difference between `on_disconnect` and `on_close` event listeners ?

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -5,5 +5,5 @@ from .wsprotocols import WSSProtocol, WSCProtocol
 from .exceptions import ParameterConflict
 from .collector import EventCollector
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __author__ = "Cybertron"

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -3,6 +3,7 @@ from .server import ServerSocket
 from .models import Message, Object
 from .wsprotocols import WSSProtocol, WSCProtocol
 from .exceptions import ParameterConflict
+from .collector import EventCollector
 
-__version__ = "1.9.0"
+__version__ = "2.0.0"
 __author__ = "Cybertron"

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -4,5 +4,5 @@ from .models import Message, Object
 from .wsprotocols import WSSProtocol, WSCProtocol
 from .exceptions import ParameterConflict
 
-__version__ = "1.5.0"
+__version__ = "1.9.0"
 __author__ = "Cybertron"

--- a/ws/base.py
+++ b/ws/base.py
@@ -26,6 +26,8 @@ class BaseSocket:
         ...
     @enforce_type
     def on(self, event: to_event):
+        if event not in self.events:
+            raise EventNotFound(f"There is no registerable event with the name \"{event}\".")
         def decorator(coro: typing.Coroutine):
             if not inspect.iscoroutinefunction(coro):
                 raise TypeError(f"Expected a coroutine function found {type(coro).__name__}.")
@@ -45,6 +47,7 @@ class BaseSocket:
         ...
     @enforce_type
     def wait_for(self, event: to_event, *, check = None, timeout: float = None):
+        if event not in self.events: raise EventNotFound(f"There is no registerable event with the name \"{event}\".")
         future = self.loop.create_future()
         if check in [True, None, False]:
             check = lambda *args: True if check in [True, None] else False

--- a/ws/base.py
+++ b/ws/base.py
@@ -1,8 +1,10 @@
-import typing, asyncio
+import typing, asyncio, inspect
 from typing import overload
 
 from .utils import to_event, enforce_type
 from .models import Object
+from .collector import EventCollector
+from .exceptions import EventNotFound
 
 class BaseSocket:
     def __init__(self):
@@ -17,6 +19,7 @@ class BaseSocket:
             'disconnect_collector':[],
             'close_collector': [],
         })
+        self.events = ['message', 'connect', 'ready', 'close', 'disconnect']
         self.loop = asyncio.get_event_loop()
     @overload
     def on(self, event: str):
@@ -24,12 +27,16 @@ class BaseSocket:
     @enforce_type
     def on(self, event: to_event):
         def decorator(coro: typing.Coroutine):
+            if not inspect.iscoroutinefunction(coro):
+                raise TypeError(f"Expected a coroutine function found {type(coro).__name__}.")
             if not self.listeners[event]: 
                 self.listeners[event] = [coro]
             else: 
                 self.listeners[event].append(coro)
         return decorator
     def event(self, coro: typing.Coroutine):
+        if not inspect.iscoroutinefunction(coro):
+            raise TypeError(f"Expected a coroutine function found {type(coro).__name__}.")
         if coro.__name__.startswith("on_"): self.listeners[coro.__name__[3:]].append(coro)
     @overload
     def wait_for(self, event: str, *, 
@@ -43,4 +50,16 @@ class BaseSocket:
             check = lambda *args: True if check in [True, None] else False
         self.listeners[f"{event}_collector"].append((future, check))
         return asyncio.wait_for(future, timeout=timeout)
-        
+    @classmethod
+    def Collector(websocket, time: float):
+        return EventCollector(websocket=websocket, time=time)
+    @overload
+    def get_listeners(self, event: typing.Optional[str] = None) -> typing.Union[Object, typing.List[typing.Coroutine]]:
+        ...
+    def get_listeners(self, event: str = None):
+        event = to_event(event)
+        if event:
+            if event not in self.events: raise EventNotFound(f"There is no registerable event with the name \"{event}\".")
+            return self.listeners[event]
+        else:
+            return Object({event_name:listeners for event_name, listeners in self.listeners.items() if not event_name.endswith("_collector")})

--- a/ws/base.py
+++ b/ws/base.py
@@ -1,8 +1,7 @@
 import typing
 from typing import overload
 
-from .utils.converters import event
-from .utils import enforce_type
+from .utils import to_event, enforce_type
 from .models import Object
 
 class BaseSocket:
@@ -18,7 +17,7 @@ class BaseSocket:
     def on(self, event: str):
         ...
     @enforce_type
-    def on(self, evnt: event):
+    def on(self, evnt: to_event):
         def decorator(coro: typing.Coroutine):
             if not self.listeners[evnt]: 
                 self.listeners[evnt] = [coro]

--- a/ws/base.py
+++ b/ws/base.py
@@ -1,4 +1,4 @@
-import typing
+import typing, asyncio
 from typing import overload
 
 from .utils import to_event, enforce_type
@@ -12,17 +12,35 @@ class BaseSocket:
             'ready':[],
             'close':[],
             'disconnect': [],
+            'message_collector': [],
+            'connect_collector': [],
+            'disconnect_collector':[],
+            'close_collector': [],
         })
+        self.loop = asyncio.get_event_loop()
     @overload
     def on(self, event: str):
         ...
     @enforce_type
-    def on(self, evnt: to_event):
+    def on(self, event: to_event):
         def decorator(coro: typing.Coroutine):
-            if not self.listeners[evnt]: 
-                self.listeners[evnt] = [coro]
+            if not self.listeners[event]: 
+                self.listeners[event] = [coro]
             else: 
-                self.listeners[evnt].append(coro)
+                self.listeners[event].append(coro)
         return decorator
     def event(self, coro: typing.Coroutine):
-        if coro.__name__.startswith("on_"): self.listeners[coro.__name__[3:]].append(coro) 
+        if coro.__name__.startswith("on_"): self.listeners[coro.__name__[3:]].append(coro)
+    @overload
+    def wait_for(self, event: str, *, 
+                       check: typing.Optional[typing.Callable] = None, 
+                       timeout: typing.Optional[float] = None):
+        ...
+    @enforce_type
+    def wait_for(self, event: to_event, *, check = None, timeout: float = None):
+        future = self.loop.create_future()
+        if check in [True, None, False]:
+            check = lambda *args: True if check in [True, None] else False
+        self.listeners[f"{event}_collector"].append((future, check))
+        return asyncio.wait_for(future, timeout=timeout)
+        

--- a/ws/client.py
+++ b/ws/client.py
@@ -10,7 +10,6 @@ from .wsprotocols import WSCProtocol
 class ClientSocket(BaseSocket):
     def __init__(self):
         super().__init__()
-        self.loop = asyncio.get_event_loop()
         self.listeners['message'].append(self.on_message)
         self.listeners['connect'].append(self.on_connect)
         self.listeners['disconnect'].append(self.on_disconnect)
@@ -29,13 +28,19 @@ class ClientSocket(BaseSocket):
                     data = json.loads(message)
                 except JSONDecodeError:
                     data = message
-                await asyncio.wait([coro(Message(data=data,
-                                                 websocket=self.connection,
-                                                 created_at=datetime.utcnow()
-                                                )) for coro in self.listeners['message']])
+                message_cls: Message = Message(data=data, websocket=self.connection, created_at=datetime.utcnow())
+                self.loop.create_task(asyncio.wait(
+                    [coro(message_cls) for coro in self.listeners['message']]+[self.__collector_verifier(futures, 'message', message_cls) 
+                     for futures in self.listeners.message_collector
+                    ]
+                ))
         except ConnectionClosedError as e:
             self.disconnection = Object({'code': e.code, 'reason': e.reason, 'disconnected': True})
-            await asyncio.wait([coro(e.code, e.reason) for coro in self.listeners.disconnect])
+            await asyncio.wait([coro(e.code, e.reason) for coro in self.listeners.disconnect]+[
+                     self.__collector_verifier(futures, 'disconnect', e.code, e.reason) 
+                     for futures in self.listeners.disconnect_collector
+                    ]
+            )
             return e
     async def __on_connect(self):
         await asyncio.wait([coro() for coro in self.listeners['connect']])
@@ -45,15 +50,24 @@ class ClientSocket(BaseSocket):
         pass
     async def on_close(self, code, reason):
         pass
+    async def __collector_verifier(self, futures, event, *event_data):
+        if futures[1](*event_data):
+            try:
+                futures[0].set_result(event_data[0] if len(event_data) == 1 else event_data)
+                self.listeners[f"{event}_collector"].remove(futures)
+            except asyncio.InvalidStateError:
+                self.listeners[f"{event}_collector"].remove(futures)
     async def __main(self, ws_url):
         self.connection = await websockets.connect(ws_url, create_protocol=WSCProtocol)
-        done, pending = await asyncio.wait([self.__message_consumer(),
-                            self.__on_connect()
-                            ], return_when=asyncio.ALL_COMPLETED)
-        if ConnectionClosedError in [type(ret) for ret in done]: return
+        self.loop.create_task(self.__on_connect())
+        done, pending = await asyncio.wait([self.__message_consumer()], return_when=asyncio.ALL_COMPLETED)
+        if ConnectionClosedError in [type(ret.result()) for ret in done]: return
         self.disconnection = Object({'code': self.connection.close_code, 'reason': self.connection.close_reason, 'disconnected': True})
-        await asyncio.wait([coro(self.connection.close_code, self.connection.close_reason) for coro in self.listeners.close])
+        await asyncio.wait([coro(self.connection.close_code, self.connection.close_reason) for coro in self.listeners.close]+[
+                     self.__collector_verifier(futures, 'close', self.connection.close_code, self.connection.close_reason) 
+                     for futures in self.listeners.close_collector
+                    ])
     async def send(self, content: typing.Any = None, *, data: dict = None):
         await self.connection.send(content=content, data=data)
-    async def close(self, code: int, reason: str = ''):
+    async def close(self, code: int = 1000, reason: str = ''):
         await self.connection.close(code=code, reason=reason)

--- a/ws/collector.py
+++ b/ws/collector.py
@@ -1,0 +1,18 @@
+import typing, datetime, asyncio
+
+class EventCollector:
+    def __init__(self, websocket, time: float) -> None:
+        self.__websocket = websocket
+        self.__time = time
+    async def collect(self, event: str, check: typing.Callable = None) -> typing.List[typing.Any]:
+        collected = []
+        start_time = datetime.datetime.utcnow()
+        while (datetime.datetime.utcnow() - start_time).total_seconds() < self.__time:
+            try:
+                event_data = await self.__websocket.wait_for(event, 
+                                                             check=check, 
+                                                             timeout=self.__time - (datetime.datetime.utcnow()-start_time).total_seconds())                
+                collected.append(event_data)
+            except asyncio.TimeoutError:
+                pass
+        return collected

--- a/ws/exceptions/__init__.py
+++ b/ws/exceptions/__init__.py
@@ -1,3 +1,4 @@
 from .parameter import ParameterConflict
+from .event import EventNotFound
 
-__all__ = ["ParameterConflict"]
+__all__ = ["ParameterConflict", "EventNotFound"]

--- a/ws/exceptions/event.py
+++ b/ws/exceptions/event.py
@@ -1,0 +1,3 @@
+class EventNotFound(Exception):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)

--- a/ws/models/message.py
+++ b/ws/models/message.py
@@ -10,4 +10,7 @@ class Message:
         self.data: typing.Any = Object(data) if type(data) == dict else data
         self.author: typing.Union[WSSProtocol, WSCProtocol, None] = websocket
         self.created_at: datetime.datetime = created_at
-    
+    def __repr__(self) -> str:
+        return f"<Message {'message' if type(self.data) != Object else 'data'}={self.data} author={self.author} created_at={self.created_at}>"
+    def __str__(self) -> str:
+        return str(self.data)

--- a/ws/server.py
+++ b/ws/server.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import typing, websockets, asyncio, json
 from json.decoder import JSONDecodeError
-from websockets import ConnectionClosedError
+from websockets import ConnectionClosedError, ConnectionClosedOK
 
 from .base import BaseSocket
 from .models.message import Message, Object
@@ -16,6 +16,7 @@ class ServerSocket(BaseSocket):
         self.listeners.connect.append(self.on_connect)
         self.listeners.ready.append(self.on_ready)
         self.listeners.disconnect.append(self.on_disconnect)
+        self.listeners.close.append(self.on_close)
         self.clients = []
         self.disconnected_clients = []
     def listen(self, addr:str, port:int):
@@ -29,7 +30,7 @@ class ServerSocket(BaseSocket):
         pass
     async def __message_consumer(self, websocket):
         try:
-            async for message in websocket:
+            async for message in websocket:             
                 try:
                     data = json.loads(message)
                 except JSONDecodeError:
@@ -38,20 +39,30 @@ class ServerSocket(BaseSocket):
                                                 websocket=websocket, 
                                                 created_at=datetime.utcnow())) for coro in self.listeners.message])
         except ConnectionClosedError as e:
+            self.clients.remove(websocket)
             self.disconnected_clients.append({websocket: Object({'code': e.code, 'reason': e.reason, 'disconnected': True})})
             await asyncio.wait([coro(websocket, e.code, e.reason) for coro in self.listeners.disconnect])
+            return e
     async def __on_connect(self, client, path):
         await asyncio.wait([coro(client, path) for coro in self.listeners.connect])
     async def on_connect(self, client, path):
         pass
     async def on_disconnect(self, client, code, reason):
         pass
+    async def on_close(self, client, code, reason):
+        pass
     async def on_ready(self):
         pass
     async def __main(self, websocket, path):
         self.clients.append(websocket)
-        await asyncio.wait([self.__message_consumer(websocket),
+        done, pending = await asyncio.wait([self.__message_consumer(websocket),
                             self.__on_connect(websocket, path)
-                            ])
+                            ], return_when=asyncio.ALL_COMPLETED)
+        if ConnectionClosedError in [type(ret) for ret in done]: return
+        self.clients.remove(websocket)
+        self.disconnected_clients.append({websocket: Object({'code': websocket.close_code, 'reason': websocket.close_reason, 'disconnected': True})})
+        await asyncio.wait([coro(websocket, websocket.close_code, websocket.close_reason) for coro in self.listeners.close])
     async def send(self, client, content: typing.Any = None, *, data: dict = None):
         await client.send(content=content, data=data)
+    async def close(self, client, *, code: int, reason: str = ''):
+        await client.close(code=code, reason=reason)

--- a/ws/server.py
+++ b/ws/server.py
@@ -1,17 +1,15 @@
 from datetime import datetime
 import typing, websockets, asyncio, json
 from json.decoder import JSONDecodeError
-from websockets import ConnectionClosedError, ConnectionClosedOK
+from websockets import ConnectionClosedError
 
 from .base import BaseSocket
 from .models.message import Message, Object
 from .wsprotocols import WSSProtocol
 
-
 class ServerSocket(BaseSocket):
     def __init__(self):
         super().__init__()
-        self.loop = asyncio.get_event_loop()
         self.listeners.message.append(self.on_message)
         self.listeners.connect.append(self.on_connect)
         self.listeners.ready.append(self.on_ready)
@@ -24,7 +22,7 @@ class ServerSocket(BaseSocket):
         self.port = port
         self.server = websockets.serve(self.__main, addr, port, create_protocol = WSSProtocol)
         self.loop.run_until_complete(self.server)
-        self.loop.run_until_complete(asyncio.wait([coro() for coro in self.listeners.ready]))
+        self.loop.run_until_complete(asyncio.wait([coro() for coro in self.listeners.ready if type(coro) != tuple]))
         self.loop.run_forever()
     async def on_message(self, message):
         pass
@@ -35,16 +33,23 @@ class ServerSocket(BaseSocket):
                     data = json.loads(message)
                 except JSONDecodeError:
                     data = message
-                await asyncio.wait([coro(Message(data=data, 
-                                                websocket=websocket, 
-                                                created_at=datetime.utcnow())) for coro in self.listeners.message])
+                message_cls: Message = Message(data=data, websocket=websocket, created_at=datetime.utcnow())
+                self.loop.create_task(asyncio.wait(
+                     [coro(message_cls) for coro in self.listeners.message]+[self.__collector_verifier(futures, 'message', message_cls) 
+                     for futures in self.listeners.message_collector
+                    ]))
         except ConnectionClosedError as e:
             self.clients.remove(websocket)
             self.disconnected_clients.append({websocket: Object({'code': e.code, 'reason': e.reason, 'disconnected': True})})
-            await asyncio.wait([coro(websocket, e.code, e.reason) for coro in self.listeners.disconnect])
+            await asyncio.wait([coro(websocket, e.code, e.reason) for coro in self.listeners.disconnect]+[
+                     self.__collector_verifier(futures, 'disconnect', e.code, e.reason) 
+                     for futures in self.listeners.disconnect_collector
+                    ])
             return e
     async def __on_connect(self, client, path):
-        await asyncio.wait([coro(client, path) for coro in self.listeners.connect])
+        await asyncio.wait([coro(client, path) for coro in self.listeners.connect]+[self.__collector_verifier(futures, 'connect', client, path) 
+                     for futures in self.listeners.connect_collector
+                    ])
     async def on_connect(self, client, path):
         pass
     async def on_disconnect(self, client, code, reason):
@@ -53,16 +58,25 @@ class ServerSocket(BaseSocket):
         pass
     async def on_ready(self):
         pass
+    async def __collector_verifier(self, futures, event, *event_data):
+        if futures[1](*event_data):
+            try: 
+                futures[0].set_result(event_data[0] if len(event_data) == 1 else event_data)
+                self.listeners[f"{event}_collector"].remove(futures)
+            except asyncio.InvalidStateError:
+                self.listeners[f"{event}_collector"].remove(futures)
     async def __main(self, websocket, path):
         self.clients.append(websocket)
-        done, pending = await asyncio.wait([self.__message_consumer(websocket),
-                            self.__on_connect(websocket, path)
-                            ], return_when=asyncio.ALL_COMPLETED)
-        if ConnectionClosedError in [type(ret) for ret in done]: return
+        self.loop.create_task(self.__on_connect(websocket, path))
+        done, pending = await asyncio.wait([self.__message_consumer(websocket)], return_when=asyncio.ALL_COMPLETED)
+        if ConnectionClosedError in [type(ret.result()) for ret in done]: return
         self.clients.remove(websocket)
         self.disconnected_clients.append({websocket: Object({'code': websocket.close_code, 'reason': websocket.close_reason, 'disconnected': True})})
-        await asyncio.wait([coro(websocket, websocket.close_code, websocket.close_reason) for coro in self.listeners.close])
+        await asyncio.wait([coro(websocket, websocket.close_code, websocket.close_reason) for coro in self.listeners.close]+[
+                     self.__collector_verifier(futures, 'close', websocket, websocket.close_code, websocket.close_reason) 
+                     for futures in self.listeners.close_collector
+                    ])
     async def send(self, client, content: typing.Any = None, *, data: dict = None):
         await client.send(content=content, data=data)
-    async def close(self, client, *, code: int, reason: str = ''):
+    async def close(self, client, *, code: int = 1000, reason: str = ''):
         await client.close(code=code, reason=reason)

--- a/ws/utils/__init__.py
+++ b/ws/utils/__init__.py
@@ -1,3 +1,4 @@
 from .typing_checking import enforce_type
+from .converters import to_event, datetime_to_dict
 
-__all__ = ['enforce_type']
+__all__ = ['enforce_type', 'to_event', 'datetime_to_dict']

--- a/ws/utils/converters.py
+++ b/ws/utils/converters.py
@@ -1,3 +1,15 @@
+import datetime
 
-def event(eve: str):
+def to_event(eve: str):
     return eve.strip().lower()
+
+def datetime_to_dict(dt: datetime.datetime):
+    return {
+		'year':dt.year,
+		'month':dt.month,
+		'day':dt.day,
+		'hour':dt.hour,
+		'minute':dt.minute,
+		'second':dt.second,
+		'millisecond':dt.microsecond
+	}

--- a/ws/utils/typing_checking.py
+++ b/ws/utils/typing_checking.py
@@ -5,9 +5,9 @@ def enforce_type(func: typing.Union[typing.Callable, typing.Coroutine]):
     def wrapper(*args, **kwargs):
         defs, args, kwargs = get_defaults(func), list(args).copy(), kwargs.copy()
         for key, val in defs.items():
-            if val[1] in [Parameter.POSITIONAL_ONLY, Parameter.VAR_POSITIONAL] and len(args) > val[2] and key not in kwargs:
+            if val[1] in [Parameter.POSITIONAL_ONLY, Parameter.VAR_POSITIONAL, Parameter.POSITIONAL_OR_KEYWORD] and len(args) > val[2] and key not in kwargs:
                 args.insert(val[2], val[0])
-            elif val[1] in [Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY, Parameter.VAR_KEYWORD] and key not in kwargs:
+            elif val[1] in [Parameter.KEYWORD_ONLY, Parameter.VAR_KEYWORD] and key not in kwargs:
                 kwargs[key] = val[0]
         annotation_vals = {list(func.__code__.co_varnames).index(key):vals for key, vals in func.__annotations__.items()}
         args = [annotation_vals[j](i) if j in list(annotation_vals.keys()) and i != None else i for i,j in zip(args, range(len(args)))]

--- a/ws/utils/typing_checking.py
+++ b/ws/utils/typing_checking.py
@@ -1,4 +1,4 @@
-import typing, inspect
+import typing, inspect, asyncio
 from inspect import Parameter
 
 def enforce_type(func: typing.Union[typing.Callable, typing.Coroutine]):
@@ -10,9 +10,10 @@ def enforce_type(func: typing.Union[typing.Callable, typing.Coroutine]):
             elif val[1] in [Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY, Parameter.VAR_KEYWORD] and key not in kwargs:
                 kwargs[key] = val[0]
         annotation_vals = {list(func.__code__.co_varnames).index(key):vals for key, vals in func.__annotations__.items()}
-        args = [annotation_vals[j](i) if j in list(annotation_vals.keys()) else i for i,j in zip(args, range(len(args)))]
-        kwargs = {key:func.__annotations__[key](value) if key in func.__annotations__ else value for key, value in kwargs.items()}
-        return func(*args, **kwargs)
+        args = [annotation_vals[j](i) if j in list(annotation_vals.keys()) and i != None else i for i,j in zip(args, range(len(args)))]
+        kwargs = {key:func.__annotations__[key](value) if key in func.__annotations__ and value != None else value for key, value in kwargs.items()}
+        if inspect.iscoroutinefunction(func): return asyncio.run(func(*args, **kwargs))
+        else: return func(*args, **kwargs)
     return wrapper
 
 def get_defaults(func: typing.Union[typing.Callable, typing.Coroutine]):

--- a/ws/wsprotocols/client.py
+++ b/ws/wsprotocols/client.py
@@ -22,6 +22,6 @@ class WSCProtocol(websockets.WebSocketClientProtocol):
         except TypeError as e:
             raise TypeError(". ".join(list(e.args)))
     def __repr__(self) -> str:
-        return f"<WSServerProtocol remote_address={self.remote_address} local_address={self.local_address}>"
+        return f"<WSClientProtocol remote_address={self.remote_address} local_address={self.local_address}>"
     def __str__(self) -> str:
         return self.__repr__()


### PR DESCRIPTION
on_close event listener is different from on_disconnect. on_disconnect is called when there was a ConnectionClosedError during handling of the internal message consumer while on_close is called when either of the sides have properly closed the connection leading to the internal message consumer exiting / returning. Unlike on_disconnect, on_close is called on both sides upon closing connection by anyone side.